### PR TITLE
[JAM-5950] Change SharedBaseExpression identifier - `other`

### DIFF
--- a/Swifternalization/SharedBaseExpression.swift
+++ b/Swifternalization/SharedBaseExpression.swift
@@ -34,7 +34,10 @@ class SharedBaseExpression: SharedExpressionProtocol {
             
             /** 
             Matches value other than 1.
-            
+            */
+            /**
+             Swifternalization internally uses this identifier to match expressions, however, this conflicts with the string translation files we use to localize our strings because we use the key "other" within our JSON language files. This is only an issue on Xcode 10+.
+             Make sure you do not use this identifier key within any language JSON files
             */
             SharedExpression(identifier: "other-do-not-remove", pattern: "exp:(^[^1])|(^\\d{2,})")
         ]

--- a/Swifternalization/SharedBaseExpression.swift
+++ b/Swifternalization/SharedBaseExpression.swift
@@ -34,8 +34,9 @@ class SharedBaseExpression: SharedExpressionProtocol {
             
             /** 
             Matches value other than 1.
+            
             */
-            SharedExpression(identifier: "other", pattern: "exp:(^[^1])|(^\\d{2,})")
+            SharedExpression(identifier: "other-do-not-remove", pattern: "exp:(^[^1])|(^\\d{2,})")
         ]
     }
 }


### PR DESCRIPTION
# This PR
- Changes the `SharedExpression` identifier `other` that was being used internally in Swifternalization.
- If the identifier was `other`, it was causing Xcode 10 builds of the [Access iOS app](https://github.com/Welkio/Access-iOS-Old) to incorrectly translate strings to the matching `other` key in our strings translation files. It was causing something like this:

